### PR TITLE
Remove custom attribute in calendarRead

### DIFF
--- a/app.py
+++ b/app.py
@@ -43,7 +43,6 @@ def welcomePage():
 
 @app.route('/calendarRead', methods=['POST'])
 def calendarRead():
-    custom_attribute = request.form['custom_attribute']
     # pdb.set_trace()
     # format start/end as ms since epoch
 


### PR DESCRIPTION
Calendar JSON feed was not being returned if a custom attribute wasn't sent in the POST request