### PR TITLE
Add support for JSON requests (#21)

### DIFF
--- a/helpers.py
+++ b/helpers.py
@@ -19,8 +19,10 @@ def mongo_to_dict(obj):
 
 
 def request_to_dict(request):
-    """Convert incoming flask requests into a dict"""
-    req_dict = request.values.to_dict()
+    """Convert incoming flask requests for objects into a dict"""
+    req_dict = request.values.to_dict(flat=True)
+    if request.is_json:
+        req_dict = request.get_json()  # get_dict returns python dictionary object
     obj_dict = {k: v for k, v in req_dict.items() if v != ""}
 
     return obj_dict


### PR DESCRIPTION
* Added JSON support to add event POST requests

* Removed unnecessary to_dict() call

* Trying returning number instead of string when responding to POST

* Added debug logging

* Fixed edit in wrong place (labels API vs events API)

* Event API responding with JSON

* Needed to cast to string before calling jsonify

* Fixed response crash by wrapping jsonify in make_response

* Fixed crash on invalid request. Returns error in JSON format to client.