### PR TITLE
Add setup and teardown scripts for heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: python3 app.py
+web: python app.py

--- a/app.json
+++ b/app.json
@@ -11,8 +11,6 @@
     },
     "DB_NAME": {
       "description": "The name of the database to use.",
-      "value": "testing",
-      "required": true
     },
     "FLASK_DEBUG": {
       "description": "Disable Flask debug mode.",

--- a/app.json
+++ b/app.json
@@ -17,7 +17,7 @@
     "FLASK_DEBUG": {
       "description": "Disable Flask debug mode.",
       "value": "False",
-      "required":
+      "required": true
     },
     "HEROKU_APP_NAME": {
       "required": true

--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
     },
     "HEROKU_APP_NAME": {
       "required": true
-    },
+    }
   },
   "formation": {
   },

--- a/app.json
+++ b/app.json
@@ -9,9 +9,6 @@
       "description": "The connection URI for MongoDB.",
       "required": true
     },
-    "DB_NAME": {
-      "description": "The name of the database to use.",
-    },
     "FLASK_DEBUG": {
       "description": "Disable Flask debug mode.",
       "value": "False",

--- a/app.json
+++ b/app.json
@@ -1,6 +1,8 @@
 {
   "name": "ABE",
   "scripts": {
+    "postdeploy": "python postdeploy.py",
+    "pr-predestroy": "python pr-predestroy.py"
   },
   "env": {
     "MONGO_URI": {
@@ -15,8 +17,11 @@
     "FLASK_DEBUG": {
       "description": "Disable Flask debug mode.",
       "value": "False",
+      "required":
+    },
+    "HEROKU_APP_NAME": {
       "required": true
-    }
+    },
   },
   "formation": {
   },

--- a/database.py
+++ b/database.py
@@ -15,7 +15,7 @@ else:
     uri = None
     db_name = "no-config"
 mongo_uri = os.getenv('MONGO_URI', uri) if not use_local else None
-mongo_db_name = os.getenv('DB_NAME', db_name)
+mongo_db_name = os.getenv('DB_NAME', os.getenv('HEROKU_APP_NAME', db_name))
 
 connect(mongo_db_name, host=mongo_uri)
 

--- a/database.py
+++ b/database.py
@@ -4,6 +4,7 @@ from mongoengine import *
 from document_models import Event, Label, RecurringEventExc
 import os
 import logging
+logging.basicConfig(level=logging.DEBUG)
 
 config_present = os.path.isfile("mongo_config.py")
 env_present = os.environ.get('MONGO_URI')

--- a/postdeploy.py
+++ b/postdeploy.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Script used to create databases for Heroku review apps"""
+import logging
+logging.basicConfig(level=logging.DEBUG)
+import os
+from sample_data import load_data
+from pymongo import MongoClient
+
+import pdb
+
+logging.info('Performing postdeploy process')
+db_name = os.getenv("HEROKU_APP_NAME", "testing")
+logging.warning('Setting env variable "DB_NAME" to "{}"'.format(db_name))
+os.environ['DB_NAME'] = db_name
+logging.warning('Dropping db "{}"'.format(db_name))
+from database import mongo_uri, mongo_db_name
+client = MongoClient(mongo_uri)  # use pymongo to drop database
+client.drop_database(db_name)
+client.close()
+logging.warning('Filling db "{}" with sample data'.format(db_name))
+import database as db
+load_data(db)  # fill database with mongoengine
+logging.info('Finished postdeploy process')

--- a/postdeploy.py
+++ b/postdeploy.py
@@ -11,8 +11,6 @@ import pdb
 
 logging.info('Performing postdeploy process')
 db_name = os.getenv("HEROKU_APP_NAME", "testing")
-# logging.warning('Setting env variable "DB_NAME" to "{}"'.format(db_name))
-# os.environ['DB_NAME'] = db_name
 logging.warning('Dropping db "{}"'.format(db_name))
 from database import mongo_uri, mongo_db_name
 client = MongoClient(mongo_uri)  # use pymongo to drop database

--- a/postdeploy.py
+++ b/postdeploy.py
@@ -12,7 +12,7 @@ import pdb
 logging.info('Performing postdeploy process')
 db_name = os.getenv("HEROKU_APP_NAME", "testing")
 logging.warning('Setting env variable "DB_NAME" to "{}"'.format(db_name))
-os.environ['DB_NAME'] = db_name
+# os.environ['DB_NAME'] = db_name
 logging.warning('Dropping db "{}"'.format(db_name))
 from database import mongo_uri, mongo_db_name
 client = MongoClient(mongo_uri)  # use pymongo to drop database

--- a/postdeploy.py
+++ b/postdeploy.py
@@ -11,7 +11,7 @@ import pdb
 
 logging.info('Performing postdeploy process')
 db_name = os.getenv("HEROKU_APP_NAME", "testing")
-logging.warning('Setting env variable "DB_NAME" to "{}"'.format(db_name))
+# logging.warning('Setting env variable "DB_NAME" to "{}"'.format(db_name))
 # os.environ['DB_NAME'] = db_name
 logging.warning('Dropping db "{}"'.format(db_name))
 from database import mongo_uri, mongo_db_name

--- a/pr-predestroy.py
+++ b/pr-predestroy.py
@@ -6,7 +6,7 @@ import os
 from pymongo import MongoClient
 
 logging.info('Performing predestroy process')
-db_name = os.getenv('DB_NAME', None)
+db_name = os.getenv('HEROKU_APP_NAME', None)
 if db_name:
     logging.warning('Dropping db {}'.format(db_name))
     from database import mongo_uri, mongo_db_name

--- a/pr-predestroy.py
+++ b/pr-predestroy.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+"""Script used to drop databases for Heroku review apps after closing"""
+import logging
+logging.basicConfig(level=logging.DEBUG)
+import os
+from pymongo import MongoClient
+
+logging.info('Performing predestroy process')
+db_name = os.getenv('DB_NAME', None)
+if db_name:
+    logging.warning('Dropping db {}'.format(db_name))
+    from database import mongo_uri, mongo_db_name
+    client = MongoClient(mongo_uri)  # use pymongo to drop database
+    client.drop_database(db_name)
+    client.close()
+else:
+    logging.info('No env variable found with name "DB_NAME"')
+logging.info('Finished predestroy process')

--- a/sample_data.py
+++ b/sample_data.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 """Sample data that can be added to the database"""
 from datetime import datetime
 
@@ -47,13 +48,13 @@ sample_events = [
         },
     'sub_events' : [
        {'title':'Not a club',
-        'start': datetime(2017, 7, 3, 16), 
+        'start': datetime(2017, 7, 3, 16),
         'end': datetime(2017, 7, 3, 18),
         'rec_id': datetime(2017,7,3,15)
         },
         {'location': 'LOOOOOOOD',
         'description': 'reading NEWL BOOKS',
-        'start': datetime(2017, 6, 26, 15), 
+        'start': datetime(2017, 6, 26, 15),
         'end': datetime(2017, 6, 26, 19),
         'rec_id': datetime(2017,6,26,15)
         }
@@ -114,12 +115,16 @@ sample_labels = [
     }
 ]
 
-if __name__ == '__main__':  # import data
+def load_data(db, event_data=sample_events, label_data=sample_labels):
     import logging
-    import database as db
+    logging.basicConfig(level=logging.DEBUG)
     logging.info("Inserting sample event data")
-    for event in sample_events:
+    for event in event_data:
         db.Event(**event).save()
     logging.info("Inserting sample label data")
-    for label in sample_labels:
+    for label in label_data:
         db.Label(**label).save()
+
+if __name__ == '__main__':  # import data
+    import database as db
+    load_data(db)


### PR DESCRIPTION
These additions will make review apps automatically create databases with their name and fill them with sample data. When the review apps are closed they automatically delete their databases.
This is accomplished with `postdeploy.py` and `pr-predestroy.py`, which are called by Heroku in the `scripts` section of `app.json`.