### PR TITLE
Enable ACME (LetsEncrypt)

### DIFF
--- a/tests/test_https_redirection.sh
+++ b/tests/test_https_redirection.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash -eu
+
+# Usage:
+#    env FLASK_DEBUG=False python run.py
+# In another terminal:
+#    ./tests/test_https_redirection.sh
+#
+# Test HTTPS redirection.
+#
+# TODO: Move this test to Python so that it can be run as part of the test
+# suite. This requires modifying app instantiation to use an app factory
+# <http://flask.pocoo.org/docs/0.12/patterns/appfactories/#app-factories>.
+
+function summary {
+    if [[ $? == 0 ]]; then
+        echo 'all tests passed' 1>&2
+    else
+        echo 'some tests failed' 1>&2
+    fi
+}
+trap summary EXIT
+
+curl -sv http://0.0.0.0:3000/ -o /dev/null 2>&1 | egrep '< HTTP/1.0 301 MOVED PERMANENTLY'
+curl -sv http://0.0.0.0:3000/ -o /dev/null 2>&1 | egrep '< Location: https://0.0.0.0:3000/'
+
+curl -sv http://0.0.0.0:3000/.well-known/invalid-acme-challenge/LoqX -o /dev/null 2>&1 | egrep '< HTTP/1.0 301 MOVED PERMANENTLY'
+curl -sv http://0.0.0.0:3000/.well-known/invalid-acme-challenge/LoqX -o /dev/null 2>&1 | egrep '< Location: https://0.0.0.0:3000/'
+
+curl -sv http://0.0.0.0:3000/.well-known/acme-challenge/LoqX -o /dev/null 2>&1 | egrep '< HTTP/1.0 301 MOVED PERMANENTLY' && exit 1 || true
+curl -sv http://0.0.0.0:3000/.well-known/acme-challenge/LoqX -o /dev/null 2>&1 | egrep '< Location: https://0.0.0.0:3000/' && exit 1 || true


### PR DESCRIPTION
Requests to the ACME HTTP Challenge fixed prefix aren't redirected to HTTPS.

This fixes #143.

Also reduced the HSTS max-age, and changed redirections to permanant.

This PR contains a test of the changed functionality, but the test isn't part of the test suite, and it requires a little sleuthing to find out which part failed when it doesn't pass. Writing the test in Python instead of bash would require a bigger change to app instantiation than I wanted to make now, but should happen in lieu of putting more work into this ad-hoc test's error reporting.