### PR TITLE
Improve travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,13 @@
 language: python
 python:
-- '3.6'
+  - '3.6'
+cache: pip
 install:
-- cp .env.template .env
-- pip install pipenv
-- pipenv install --ignore-pipfile
-script: pipenv run python -m unittest
+  - cp .env.template .env
+  - pip install pipenv
+  - pipenv install --dev --ignore-pipfile
+script:
+  - pipenv run python -m unittest
 services: mongodb
 notifications:
   slack:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - '3.6'
 cache: pip
+env:
+  - PIPENV_IGNORE_VIRTUALENVS=1
 install:
   - cp .env.template .env
   - pip install pipenv

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ language: python
 python:
   - '3.6'
 cache: pip
-env:
-  - PIPENV_IGNORE_VIRTUALENVS=1
 install:
   - cp .env.template .env
   - pip install pipenv


### PR DESCRIPTION
* `pipenv install` with `--dev`.
    * We don't need these tools now, but will when we lint on Travis.
    * Also, this validates that the dev install is working.
* Cache pipfiles. (From travis file for requests, which uses pipenv — and is by its author.)
* Canonical indentation for `-` lines