### PR TITLE
Remove logging chatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ JSON list of events.)
 
 `python -m unittest`
 
-This is noisy, but should print `OK` at the end:
+This should print `OK` at the end:
 
 ```bash
 $ python -m unittest
@@ -98,14 +98,14 @@ OK
 ### abe.olin.build/events/
 
 | HTTP Method | Action              |
-|-------------|---------------------|
+| ----------- | ------------------- |
 | GET         | retrieve all events |
 | POST        | create new event    |
 
 ### abe.olin.build/events/24
 
 | HTTP Method | Action                    |
-|-------------|---------------------------|
+| ----------- | ------------------------- |
 | GET         | retrieve event with id 24 |
 | PUT         | update event with id 24   |
 | DELETE      | delete event with id 24   |
@@ -113,7 +113,7 @@ OK
 ### abe.olin.build/events/ShortScarletFrog
 
 | HTTP Method | Action                                    |
-|-------------|-------------------------------------------|
+| ----------- | ----------------------------------------- |
 | GET         | retrieve event with id "ShortScarletFrog" |
 | PUT         | update event with id "ShortScarletFrog"   |
 | DELETE      | delete event with id "ShortScarletFrog"   |
@@ -121,14 +121,14 @@ OK
 ### abe.olin.build/labels/
 
 | HTTP Method | Action              |
-|-------------|---------------------|
+| ----------- | ------------------- |
 | GET         | retrieve all labels |
 | PUT         | create new label    |
 
 ### abe.olin.build/labels/clubs
 
 | HTTP Method | Action                           |
-|-------------|----------------------------------|
+| ----------- | -------------------------------- |
 | GET         | retrieve label with name "clubs" |
 | PUT         | update label with name "clubs"   |
 | DELETE      | delete label with name "clubs"   |

--- a/abe/app.py
+++ b/abe/app.py
@@ -12,7 +12,7 @@ import os
 
 import logging
 FORMAT = "%(levelname)s:ABE: _||_ %(message)s"
-logging.basicConfig(level=logging.DEBUG, format=FORMAT)
+logging.basicConfig(level=logging.INFO, format=FORMAT)
 
 from .resource_models.event_resources import EventApi
 from .resource_models.label_resources import LabelApi

--- a/abe/sample_data.py
+++ b/abe/sample_data.py
@@ -84,7 +84,7 @@ def insert_data(db, event_data=None, label_data=None, ics_data=None):
     from .helper_functions.sub_event_helpers import find_recurrence_end
     logging.basicConfig(level=logging.DEBUG)
     if event_data:
-        logging.info("Inserting sample event data")
+        logging.debug("Inserting sample event data")
         for event in event_data:
             for key, value in event.items():
                 if type(value) is datetime:  # convert to UTC from EST
@@ -96,16 +96,16 @@ def insert_data(db, event_data=None, label_data=None, ics_data=None):
             if 'recurrence' in new_event:
                 if new_event.recurrence.forever == False:
                     new_event.recurrence_end = find_recurrence_end(new_event)
-                    logging.info("made some end recurrences: {}".format(new_event.recurrence_end))
+                    logging.debug("made some end recurrences: {}".format(new_event.recurrence_end))
             new_event.save()
     if label_data:
-        logging.info("Inserting sample label data")
+        logging.debug("Inserting sample label data")
         for index, label in enumerate(label_data):
             if 'color' not in label:
                 label['color'] = olin_colors[index]
             db.Label(**label).save()
     if ics_data:
-        logging.info("Inserting sample ics data")
+        logging.debug("Inserting sample ics data")
         for ics in ics_data:
             db.ICS(**ics).save()
 


### PR DESCRIPTION
As there get to be more unit tests (pending in various branches), it's getting more difficult to see the test results among the logging.

This change cleans up the `python -m unittest` output to where it's usable again.