### PR TITLE
README improvements

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,32 @@
+# Contributing to Atom
+
+:+1::tada: First off, thanks for taking the time to contribute to ABE! :tada::+1:
+
+The following is a set of guidelines for contributing to ABE.
+These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Styleguides
+
+### Python Styleguide
+
+New code should follow [PEP 8](https://www.python.org/dev/peps/pep-0008/)
+and [PEP 257](https://www.python.org/dev/peps/pep-0257/).
+Run `pipenv run flake8 abe` to check your code.
+Old code doesn't follow these guidelines, so you'll see a lot of noise.
+
+### Markdown Styleguide
+
+Markdown should pass [markdown-lint](https://github.com/remarkjs/remark-lint).
+
+The following editor plugins keep code in compliance with markdown-lint:
+
+* Atom: [linter-markdown](https://atom.io/packages/linter-markdown)
+* Visual Studio Code:
+  * [markdownlint](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)
+    lints Markdown files.
+  * [remark](https://marketplace.visualstudio.com/items?itemName=mrmlnc.vscode-remark)
+    beautifies Markdown files.
+
+## Acknowledgements
+
+Portions of this guide were adapted from the [Atom contribution guide](https://github.com/atom/atom/blob/master/CONTRIBUTING.md#styleguides).

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Amorphous Blob of Events
 ## Getting Started
 
 ### Environment Variables
+
 There's an [environment variable template](.env.template), which needs to be copied and may need to be changed accordingly:
 
 ```shell
@@ -14,19 +15,23 @@ $ cp .env.template .env
 It will be automagically picked up by...
 
 ### Pipenv
+
 ABE uses Pipenv for python management.
 
 First, [install pipenv](http://docs.python-guide.org/en/latest/dev/virtualenvs/#installing-pipenv). Most commonly:
+
 ```shell
 $ pip install --user pipenv
 ```
 
 To resolve python dependencies:
+
 ```shell
 $ pipenv install --dev
 ```
 
 To enter a virtual environment:
+
 ```shell
 pipenv shell
 ```
@@ -51,7 +56,9 @@ In order to connect to a mongodb instance other than your localhost, you can cre
 This configuration file is gitignored and can specify a uri for mongodb to connect to.
 
 #### Load Sample Data
+
 To load [sample data](abe/sample_data.py) into the database, run
+
 ```shell
 python -m abe.sample_data
 ```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,23 @@
 Dev: [![Build Status](https://travis-ci.org/olinlibrary/ABE.svg?branch=dev)](https://travis-ci.org/olinlibrary/ABE/branches)
 Master: [![Build Status](https://travis-ci.org/olinlibrary/ABE.svg?branch=master)](https://travis-ci.org/olinlibrary/ABE/branches)
 
-Amorphous Blob of Events
+**ABE** (Amorphous Blob of Events) is Olin's student-built store of information
+about Olin events. It enables the creation of digital experiences that share
+information about past, present, and upcoming events.
+
+## Built With ABE
+
+ABE is a platform. Some online experiences that use the data in ABE include:
+
+* [Olin Events](https://github.com/olinlibrary/abe-web) is a web view of the
+  Olin calendar. It can also be used to subscribe other calendar programs, such
+  as Google Calendar and desktop and mobile calendar clients, to ABE; and to
+  connect ABE to other calendars.
+* [FUTUREboard](https://github.com/olinlibrary/futureboard)  is a digital
+  signage platform for sharing of media, supplemented by information about
+  events happening on campus.
+* [ABE Event Schedule](https://github.com/osteele/abe-event-schedule) is an
+  experiment in deriving a conference-track-style schedule from ABE events.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # ABE
 
+Dev: [![Build Status](https://travis-ci.org/olinlibrary/ABE.svg?branch=dev)](https://travis-ci.org/olinlibrary/ABE/branches)
+Master: [![Build Status](https://travis-ci.org/olinlibrary/ABE.svg?branch=master)](https://travis-ci.org/olinlibrary/ABE/branches)
+
 Amorphous Blob of Events
 
 ## Getting Started


### PR DESCRIPTION
* Lint the README
* Add a starter [contributing template](https://help.github.com/articles/setting-guidelines-for-repository-contributors/), to (weakly) enforce the decision to keep the README linted.
* Add a stub project description, with pointers to some of the Built With ABE apps