### PR TITLE
Factor common mongodb setup out from test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,19 +136,25 @@ Ran 4 tests in 1.124s
 OK
 ```
 
+Test a specific test:
+
+```shell
+$ python -m unittest tests/test_recurrences.py
+```
+
 ## API Documentation
 
 ### abe.olin.build/events/
 
 | HTTP Method | Action              |
-|-------------|---------------------|
+| ----------- | ------------------- |
 | GET         | retrieve all events |
 | POST        | create new event    |
 
 ### abe.olin.build/events/24
 
 | HTTP Method | Action                    |
-|-------------|---------------------------|
+| ----------- | ------------------------- |
 | GET         | retrieve event with id 24 |
 | PUT         | update event with id 24   |
 | DELETE      | delete event with id 24   |
@@ -156,7 +162,7 @@ OK
 ### abe.olin.build/events/ShortScarletFrog
 
 | HTTP Method | Action                                    |
-|-------------|-------------------------------------------|
+| ----------- | ----------------------------------------- |
 | GET         | retrieve event with id "ShortScarletFrog" |
 | PUT         | update event with id "ShortScarletFrog"   |
 | DELETE      | delete event with id "ShortScarletFrog"   |
@@ -164,14 +170,14 @@ OK
 ### abe.olin.build/labels/
 
 | HTTP Method | Action              |
-|-------------|---------------------|
+| ----------- | ------------------- |
 | GET         | retrieve all labels |
 | PUT         | create new label    |
 
 ### abe.olin.build/labels/clubs
 
 | HTTP Method | Action                           |
-|-------------|----------------------------------|
+| ----------- | -------------------------------- |
 | GET         | retrieve label with name "clubs" |
 | PUT         | update label with name "clubs"   |
 | DELETE      | delete label with name "clubs"   |

--- a/tests/abe_unittest.py
+++ b/tests/abe_unittest.py
@@ -1,0 +1,33 @@
+import os
+import unittest
+
+from pymongo import MongoClient
+
+MONGODB_TEST_DB_NAME = "abe-unittest"
+os.environ["DB_NAME"] = MONGODB_TEST_DB_NAME
+os.environ["MONGO_URI"] = ""
+
+from abe import database as db  # isort:skip # noqa: E402
+
+
+class TestCase(unittest.TestCase):
+    """The abstract base class for ABE test cases.
+
+    Use this class instead of `unittest.TestCase` for tests that use the
+    database. It tears down the database after each test.
+
+    Attributes:
+        db: The MongoDB database for the test environment
+    """
+
+    def setUp(self):
+        # This import needs to happen after setting the environment variables
+        # above
+        self.db = db
+        assert db.mongo_db_name == MONGODB_TEST_DB_NAME, \
+            f"{__name__} must be imported before abe.database"
+
+    def tearDown(self):
+        client = MongoClient()
+        client.drop_database(MONGODB_TEST_DB_NAME)
+        client.close()

--- a/tests/abe_unittest.py
+++ b/tests/abe_unittest.py
@@ -3,11 +3,7 @@ import unittest
 
 from pymongo import MongoClient
 
-MONGODB_TEST_DB_NAME = "abe-unittest"
-os.environ["DB_NAME"] = MONGODB_TEST_DB_NAME
-os.environ["MONGO_URI"] = ""
-
-from abe import database as db  # isort:skip # noqa: E402
+from .context import MONGODB_TEST_DB_NAME, db
 
 
 class TestCase(unittest.TestCase):
@@ -21,6 +17,7 @@ class TestCase(unittest.TestCase):
     """
 
     def setUp(self):
+        super().setUp()
         # This import needs to happen after setting the environment variables
         # above
         self.db = db
@@ -28,6 +25,7 @@ class TestCase(unittest.TestCase):
             f"{__name__} must be imported before abe.database"
 
     def tearDown(self):
+        super().tearDown()
         client = MongoClient()
         client.drop_database(MONGODB_TEST_DB_NAME)
         client.close()

--- a/tests/context.py
+++ b/tests/context.py
@@ -7,4 +7,11 @@ import os
 import sys
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+MONGODB_TEST_DB_NAME = "abe-unittest"
+os.environ["DB_NAME"] = MONGODB_TEST_DB_NAME
+os.environ["MONGO_URI"] = ""
+
+# These imports have to go after the environment variables are set
 import abe  # isort:skip # noqa: E402 F401
+from abe import database as db  # isort:skip # noqa: E402

--- a/tests/context.py
+++ b/tests/context.py
@@ -1,12 +1,10 @@
 #!/usr/bin/env python3
 """Provide context for imports of ABE.
 Referenced from The Hitchhiker's Guide to Python.
-https://python-guide-pt-br.readthedocs.io/en/latest/writing/structure/#test-suite
+http://docs.python-guide.org/en/latest/writing/structure/#test-suite
 """
 import os
 import sys
-# sys.path.insert(0, os.path.abspath('..'))
+
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-# lib_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../modules'))
-# sys.path.append(lib_path)
-import abe
+import abe  # isort:skip # noqa: E402 F401

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -9,27 +9,20 @@ import unittest
 import flask
 from pymongo import MongoClient
 
-from abe import sample_data
-
 from . import abe_unittest
 from .context import abe  # noqa: F401
+
+# These imports have to happen after .context sets the environment variables
+import abe.app  # isort:skip
+from abe import sample_data  # isort:skip
 
 
 class AbeTestCase(abe_unittest.TestCase):
 
     def setUp(self):
-        """Setup testing environment"""
-        os.environ["DB_NAME"] = "abe-unittest"
-        os.environ["MONGO_URI"] = ""
-        import abe.app  # import abe after env so it inits correctly
+        super().setUp()
         abe.app.app.debug = True  # enable debug to prevent https redirects
         self.app = abe.app.app.test_client()
-
-    def tearDown(self):
-        """Teardown testing environment"""
-        client = MongoClient()
-        client.drop_database(os.environ['DB_NAME'])  # remove testing db
-        client.close()
 
     def test_empty_db(self):
         event_response = self.app.get('/events/')

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -5,15 +5,17 @@ database named "abe-unittest" for testing.
 """
 import os
 import unittest
+
 import flask
 from pymongo import MongoClient
-import logging
-from .context import abe
+
 from abe import sample_data
-import pdb
+
+from . import abe_unittest
+from .context import abe  # noqa: F401
 
 
-class AbeTestCase(unittest.TestCase):
+class AbeTestCase(abe_unittest.TestCase):
 
     def setUp(self):
         """Setup testing environment"""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,7 +73,3 @@ class AbeTestCase(abe_unittest.TestCase):
             response = self.app.get('/events/?start=2020-01-01&end=2021-01-01')
             # FIXME:
             self.assertEqual(response._status_code, 200)
-
-
-if __name__ == '__main__':
-    unittest.main()

--- a/tests/test_recurrences.py
+++ b/tests/test_recurrences.py
@@ -1,11 +1,7 @@
-import os
-import unittest
 from datetime import datetime
 
-from pymongo import MongoClient
-
-
-testDbName = "abe-unittest"
+from . import abe_unittest
+from .context import abe  # noqa: F401
 
 # TODO: add test cases for YEARLY frequency (are there others)?
 # TODO: add test cases for by_month, by_month_day
@@ -31,20 +27,7 @@ recurringEvents = dict(
 )
 
 
-class RecurrenceTestCase(unittest.TestCase):
-
-    def setUp(self):
-        os.environ["DB_NAME"] = testDbName
-        os.environ["MONGO_URI"] = ""
-        # These imports need to happen after setting the environment variable
-        # TODO: factor these from the tests to a test helper
-        from abe import database as db
-        self.db = db
-
-    def tearDown(self):
-        client = MongoClient()
-        client.drop_database(testDbName)
-        client.close()
+class RecurrenceTestCase(abe_unittest.TestCase):
 
     def get_test_event(self, key):
         db = self.db

--- a/tests/test_recurrences.py
+++ b/tests/test_recurrences.py
@@ -3,6 +3,9 @@ from datetime import datetime
 from . import abe_unittest
 from .context import abe  # noqa: F401
 
+# This import has to happen after .context sets the environment variables
+from abe.helper_functions import sub_event_helpers  # isort:skip
+
 # TODO: add test cases for YEARLY frequency (are there others)?
 # TODO: add test cases for by_month, by_month_day
 # TODO: add test cases for count, interval
@@ -36,8 +39,6 @@ class RecurrenceTestCase(abe_unittest.TestCase):
         return db.Event(**event)
 
     def test_instance_creation(self):
-        # This import has to happen after setUp sets the environment variables
-        from abe.helper_functions import sub_event_helpers
         event = self.get_test_event('weekly')
 
         with self.subTest("no start or end date"):

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -5,10 +5,11 @@ database named "abe-unittest" for testing.
 """
 import unittest
 
-from abe import sample_data
-
 from . import abe_unittest
 from .context import abe  # noqa: F401
+
+# This import has to happen after .context sets the environment variables
+from abe import sample_data  # isort:skip
 
 
 class SampleDataTestCase(abe_unittest.TestCase):

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -3,33 +3,20 @@
 This test suite requires a local mongodb instance and writes to/drops a
 database named "abe-unittest" for testing.
 """
-import os
 import unittest
-from pymongo import MongoClient
-import logging
-from .context import abe
+
 from abe import sample_data
-import pdb
+
+from . import abe_unittest
+from .context import abe  # noqa: F401
 
 
-class SampleDataTestCase(unittest.TestCase):
-
-    def setUp(self):
-        """Setup testing environment"""
-        os.environ["DB_NAME"] = "abe-unittest"
-        os.environ["MONGO_URI"] = ""
-        from abe import database as db
-        self.db = db
-
-    def tearDown(self):
-        """Teardown testing environment"""
-        client = MongoClient()
-        client.drop_database(os.environ['DB_NAME'])  # remove testing db
-        client.close()
+class SampleDataTestCase(abe_unittest.TestCase):
 
     def test_load_data(self):
         """Load sample data"""
         sample_data.load_data(self.db)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_sample_data.py
+++ b/tests/test_sample_data.py
@@ -17,7 +17,3 @@ class SampleDataTestCase(abe_unittest.TestCase):
     def test_load_data(self):
         """Load sample data"""
         sample_data.load_data(self.db)
-
-
-if __name__ == '__main__':
-    unittest.main()


### PR DESCRIPTION
Also:
* Fix flake8 errors
* Remove (the non-working) `if __name__ == '__main__'` from tests
* Document the unittest command-line argument instead