### PR TITLE
Minor fixes to recurrence tests

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -43,7 +43,7 @@ class AbeTestCase(unittest.TestCase):
                 data=flask.json.dumps(event),  # use flask.json for datetimes
                 content_type='application/json'
             )
-            assert response._status_code == 201  # check only status code
+            self.assertEqual(response._status_code, 201)  # check only status code
 
     def test_add_sample_labels(self):
         """Adds the sample labels to the database"""
@@ -53,7 +53,7 @@ class AbeTestCase(unittest.TestCase):
                 data=flask.json.dumps(event),
                 content_type='application/json'
             )
-            assert response._status_code == 201
+            self.assertEqual(response._status_code, 201)
 
     def test_date_range(self):
         from abe import database as db
@@ -66,17 +66,15 @@ class AbeTestCase(unittest.TestCase):
 
         with self.subTest("a one-year query returns all events"):
             response = self.app.get('/events/?start=2017-01-01&end=2018-01-01')
-            assert response._status_code == 200, f"status={response._status_code}"
+            self.assertEqual(response._status_code, 200)
             self.assertEqual(len(flask.json.loads(response.data)), 69)
 
         with self.subTest("a two-year query is too long"):
             response = self.app.get('/events/?start=2017-01-01&end=2019-01-01')
-            # FIXME:
             self.assertEqual(response._status_code, 404)
 
         with self.subTest("a one-year query works for leap years"):
             response = self.app.get('/events/?start=2020-01-01&end=2021-01-01')
-            # FIXME:
             self.assertEqual(response._status_code, 200)
 
 

--- a/tests/test_recurrences.py
+++ b/tests/test_recurrences.py
@@ -75,6 +75,5 @@ class RecurrenceTestCase(unittest.TestCase):
                 event,
                 start=datetime(2017, 7, 20),
                 end=datetime(2027, 7, 31))
-            print(instances)
             # Should return all instances of the recurring event that happen within the query range
             self.assertEqual(len(instances), 8)


### PR DESCRIPTION
* Replace assert by assertEqual, for better error reporting
* Remove a `print`
* Remove stale FIXMEs