### PR TITLE
Updates Splash Page

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Atom
+# Contributing to ABE
 
 :+1::tada: First off, thanks for taking the time to contribute to ABE! :tada::+1:
 

--- a/abe/templates/splash.html
+++ b/abe/templates/splash.html
@@ -62,6 +62,30 @@
         border-radius: 5px;
         background-color: black;
       }
+
+      #how {
+        position:absolute;
+        bottom:0;
+        right:0;
+      }
+
+      #more {
+        position:absolute;
+        top:20px;
+        right:0;
+      }
+
+      #what {
+        position:absolute;
+        top:20px;
+        left:0;
+      }
+      
+      #where {
+        position:absolute;
+        bottom:0;
+        left:0;
+      }
     </style>
   </head>
   <body>
@@ -70,6 +94,30 @@
         <div id="hat"></div>
         <div id="rim"></div>
         <h1>ABE</h1>
+      </div>
+    </a>
+    <a href="/docs/">
+      <div id="how">
+	<h1>HOW &rarr;</h1>
+        <h2>API Documentation</h2>
+      </div>
+    </a>
+    <a href="https://olin.build/">
+      <div id="more">
+	<h1>MORE &rarr;</h1>
+        <h2>Other Olin Projects</h2>
+      </div>
+    </a>
+    <a href="https://github.com/olinlibrary/abe/wiki/what-is-abe%3f">
+      <div id="what">
+	<h1>&larr; WHAT</h1>
+        <h2 style="text-align:right">Why does ABE exist?</h2>
+      </div>
+    </a>
+    <a href="https://events.olin.build/">
+      <div id="where">
+	<h1>&larr; WHERE</h1>
+        <h2 style="text-align:right">See what ABE powers</h2>
       </div>
     </a>
   </body>


### PR DESCRIPTION
Resolves #175. 

These links should help orient anyone that lands on the splash page.

The tophat still links to the main repo with README, where a lot of content is explained, including who, basic what and example projects. I added [this](https://github.com/olinlibrary/ABE/wiki/What-is-ABE%3F) page in the wiki to have any information we don't want in the README, but still could help orient people, like project history and such.

Very open to any changes in wording or design, this seemed like a rather simple but efficient solution.