### PR TITLE
PUT /labels/{id} renames event.labels

### DIFF
--- a/abe/document_models/label_documents.py
+++ b/abe/document_models/label_documents.py
@@ -33,10 +33,10 @@ class Label(Document):
     visibility 		Indicates who can see the label. Optional
                                 Takes a string
     """
-    name = StringField(required=True, unique=True)  # TODO: set to primary key?
+    name = StringField(required=True, unique=True)
     description = StringField()
     url = URLField()
     default = BooleanField(required=True, default=False)  # suggested to display by default
     parent_labels = ListField(StringField())  # rudimentary hierarchy of labels
-    color = StringField()  # suggested color for label
+    color = StringField(regex=r'#[0-9a-zA-Z]{6}')  # suggested color for label
     visibility = StringField()  # suggested visibility

--- a/abe/resource_models/label_resources.py
+++ b/abe/resource_models/label_resources.py
@@ -29,14 +29,14 @@ label_model = api.model("Label_Model", {
 class LabelApi(Resource):
     """API for interacting with all labels (searching, creating)"""
 
-    def get(self, label_name=None):
-        """Retrieve labels"""
-        if label_name:  # use label name/object id if present
-            logging.debug('Label requested: %s', label_name)
+    def get(self, id=None):
+        """Retrieve a list of labels"""
+        if id:  # use label name/object id if present
+            logging.debug('Label requested: %s', id)
             search_fields = ['name', 'id']
-            result = multi_search(db.Label, label_name, search_fields)
+            result = multi_search(db.Label, id, search_fields)
             if not result:
-                return "Label not found with identifier '{}'".format(label_name), 404
+                return "Label not found with identifier '{}'".format(id), 404
             else:
                 return mongo_to_dict(result)
         else:  # search database based on parameters
@@ -50,7 +50,7 @@ class LabelApi(Resource):
     @edit_auth_required
     @api.expect(label_model)
     def post(self):
-        """Create new label with parameters passed in through args or form"""
+        """Create a new label"""
         received_data = request_to_dict(request)
         logging.debug("Received POST data: %s", received_data)
         try:
@@ -66,14 +66,14 @@ class LabelApi(Resource):
 
     @edit_auth_required
     @api.expect(label_model)
-    def put(self, label_name):
-        """Modify individual label"""
+    def put(self, id):
+        """Modify a label's properties"""
         received_data = request_to_dict(request)
         logging.debug("Received PUT data: %s", received_data)
         search_fields = ['name', 'id']
-        result = multi_search(db.Label, label_name, search_fields)
+        result = multi_search(db.Label, id, search_fields)
         if not result:
-            return "Label not found with identifier '{}'".format(label_name), 404
+            return "Label not found with identifier '{}'".format(id), 404
 
         try:
             result.update(**received_data)
@@ -86,13 +86,13 @@ class LabelApi(Resource):
             return mongo_to_dict(result)
 
     @edit_auth_required
-    def delete(self, label_name):
-        """Delete individual label"""
-        logging.debug('Label requested: %s', label_name)
+    def delete(self, id):
+        """Delete a label"""
+        logging.debug('Label requested: %s', id)
         search_fields = ['name', 'id']
-        result = multi_search(db.Label, label_name, search_fields)
+        result = multi_search(db.Label, id, search_fields)
         if not result:
-            return "Label not found with identifier '{}'".format(label_name), 404
+            return "Label not found with identifier '{}'".format(id), 404
 
         received_data = request_to_dict(request)
         logging.debug("Received DELETE data: %s", received_data)
@@ -101,6 +101,6 @@ class LabelApi(Resource):
 
 
 api.add_resource(LabelApi, '/', methods=['GET', 'POST'], endpoint='label')
-api.add_resource(LabelApi, '/<string:label_name>',
+api.add_resource(LabelApi, '/<string:id>',
                  methods=['GET', 'PUT', 'PATCH', 'DELETE'],
-                 endpoint='label_name')
+                 endpoint='id')

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -15,6 +15,18 @@ class LabelsTestCase(abe_unittest.TestCase):
         self.app = abe.app.app.test_client()
         sample_data.load_data(self.db)
 
+    def get_label_by_name(self, name):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['name'] == name)
+
+    def get_label_by_id(self, id):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['id'] == id)
+
     def test_get(self):
         response = self.app.get('/labels/')
         self.assertEqual(response.status_code, 200)
@@ -93,23 +105,11 @@ class LabelsTestCase(abe_unittest.TestCase):
             )
             self.assertEqual(response.status_code, 201)
 
-    def get_label_by_name(self, name):
-        response = self.app.get('/labels/')
-        self.assertEqual(response.status_code, 200)
-        return next(label for label in flask.json.loads(response.data)
-                    if label['name'] == name)
-
-    def get_label_by_id(self, id):
-        response = self.app.get('/labels/')
-        self.assertEqual(response.status_code, 200)
-        return next(label for label in flask.json.loads(response.data)
-                    if label['id'] == id)
-
     def test_put(self):
         # TODO: test w/ invalid id
         # TODO: test w/ invalid data
 
-        library_label = self.get_label_by_name('library')
+        label_id = self.get_label_by_name('library')['id']
         label_data = {
             'description': 'New description',
         }
@@ -125,13 +125,37 @@ class LabelsTestCase(abe_unittest.TestCase):
 
         with self.subTest("succeeds with an authorized client"):
             response = self.app.put(
-                '/labels/' + library_label['id'],
+                '/labels/' + label_id,
                 data=flask.json.dumps(label_data),
                 content_type='application/json',
             )
             self.assertEqual(response.status_code, 200)
-            label = self.get_label_by_id(library_label['id'])
+            label = self.get_label_by_id(label_id)
             self.assertEqual(label['description'], 'New description')
+
+    def test_put_rename(self):
+        events_path = '/events/?start=2017-01-01&end=2018-01-01'
+        library_events = sum('library' in event['labels']
+                             for event in flask.json.loads(self.app.get(events_path).data))
+        self.assertGreater(library_events, 20)
+
+        label_id = self.get_label_by_name('library')['id']
+        response = self.app.put(
+            '/labels/' + label_id,
+            data=flask.json.dumps({'name': 'renamed'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        with self.subTest("updates label.name"):
+            self.assertEqual(self.get_label_by_id(label_id)['name'], 'renamed')
+
+        with self.subTest("updates event.labels lists"):
+            events = flask.json.loads(self.app.get(events_path).data)
+            unrenamed_events = sum('library' in event['labels'] for event in events)
+            renamed_events = sum('renamed' in event['labels'] for event in events)
+            self.assertEqual(unrenamed_events, 0)
+            self.assertEqual(renamed_events, library_events)
 
     def test_delete(self):
         # TODO: test success

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -76,7 +76,7 @@ class LabelsTestCase(abe_unittest.TestCase):
             )
             self.assertEqual(response.status_code, 401)
 
-        with self.subTest("succeeds when required fields are present"):
+        with self.subTest("succeeds with an authorized client"):
             response = self.app.post(
                 '/labels/',
                 data=flask.json.dumps(label_success),
@@ -93,18 +93,45 @@ class LabelsTestCase(abe_unittest.TestCase):
             )
             self.assertEqual(response.status_code, 201)
 
+    def get_label_by_name(self, name):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['name'] == name)
+
+    def get_label_by_id(self, id):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['id'] == id)
+
     def test_put(self):
-        # TODO: test success
-        # TODO: test invalid id
-        # TODO: test invalid data
+        # TODO: test w/ invalid id
+        # TODO: test w/ invalid data
+
+        library_label = self.get_label_by_name('library')
+        label_data = {
+            'description': 'New description',
+        }
+
         with self.subTest("fails when the client is not authorized"):
             response = self.app.put(
                 '/labels/library',
-                data=flask.json.dumps({'description': 'new description'}),
+                data=flask.json.dumps(label_data),
                 content_type='application/json',
                 headers={'X-Forwarded-For': '192.168.1.1'}
             )
             self.assertEqual(response.status_code, 401)
+
+        with self.subTest("succeeds with an authorized client"):
+            response = self.app.put(
+                '/labels/' + library_label['id'],
+                data=flask.json.dumps(label_data),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 200)
+            label = self.get_label_by_id(library_label['id'])
+            self.assertEqual(label['description'], 'New description')
 
     def test_delete(self):
         # TODO: test success


### PR DESCRIPTION
c23f26c *Modify the `PUT /labels` and `DEL /labels` docs and param names to suggest ids instead of names*

The code to addressing labels by name is still present, just not longer advertised.

Added a test for `PUT /events/{id}`

Completes #224.

c7ab9ac *`PUT /label/{id}` renames labels in `event.labels` array*

Completes #227