### PR TITLE
Make SHARED_SECRET optional

### DIFF
--- a/abe/auth/__init__.py
+++ b/abe/auth/__init__.py
@@ -5,6 +5,7 @@ from functools import wraps
 
 from flask import request, abort, g
 from netaddr import IPNetwork, IPSet
+import logging
 
 # A set of IP addresses with edit permission.
 #
@@ -17,7 +18,9 @@ from netaddr import IPNetwork, IPSet
 INTRANET_IPS = (IPSet([IPNetwork(s) for s in os.environ.get('INTRANET_IPS', '').split(',')])
                 if 'INTRANET_IPS' in os.environ else IPSet(['0.0.0.0/0', '0000:000::/0']))
 
-shared_secret = os.environ.get("SHARED_SECRET", None)
+shared_secret = os.environ.get("SHARED_SECRET", "")
+if not shared_secret:
+    logging.critical("SHARED_SECRET isn't set")
 
 
 def after_this_request(f):  # For setting cookie
@@ -34,7 +37,7 @@ def check_auth(req):
     Returns a Bool of passing.
     """
     client_ip = req.headers.get(
-            'X-Forwarded-For', req.remote_addr).split(',')[-1]
+        'X-Forwarded-For', req.remote_addr).split(',')[-1]
     if client_ip in INTRANET_IPS:
         @after_this_request
         def remember_computer(response):

--- a/tests/context.py
+++ b/tests/context.py
@@ -11,6 +11,7 @@ MONGODB_TEST_DB_NAME = "abe-unittest"
 os.environ["DB_NAME"] = MONGODB_TEST_DB_NAME
 os.environ["INTRANET_IPS"] = "127.0.0.1/24"
 os.environ["MONGO_URI"] = ""
+os.environ["SHARED_SECRET"] = "F8F8E5FA-680C-4169-8D94-9EC007A5B03A"
 
 os.environ['ABE_EMAIL_USERNAME'] = 'email-test-user'
 os.environ['ABE_EMAIL_PASSWORD'] = 'email-test-password'


### PR DESCRIPTION
The requirement for `SHARED_SECRET` (and the cryptic stack trace that results when it is not set) has bitten a couple of us; also, adding it to `.env` didn't work for @iblancett. Rather than track this down, I propose making this a warning.

An alternative would be to replace `shared_secret = os.environ.get("SHARED_SECRET", None)` by `shared_secret = os.environ["SHARED_SECRET"]`, for a clearer error message that happens when the app is initialized, instead of later.