### PR TITLE
Fix mongodb error handling in resource handlers

### DIFF
--- a/abe/helper_functions/mongodb_helpers.py
+++ b/abe/helper_functions/mongodb_helpers.py
@@ -1,0 +1,31 @@
+from functools import wraps
+
+import mongoengine
+
+# This is sketchy, but mongoengine doesn't export a helpful base class that
+# could be used to catch all and only input-related errors (as opposed to server
+# and implementation errors.)
+#
+# If this breaks with a future release, could be released by an extensive list
+# of the relevant errors.
+mongo_errors = tuple(mongoengine.errors.__dict__[k] for k in mongoengine.errors.__all__)
+
+
+def mongo_resource_errors(f):
+    "Decorates f to response with a 400 if a MongoDB error is raised."
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        try:
+            return f(*args, **kwargs)
+        except mongoengine.ValidationError as error:
+            return {'error_type': 'validation',
+                    'validation_errors': [str(err) for err in error.errors or [error]],
+                    'error_message': error.message,
+                    }, 400
+        except mongoengine.DoesNotExist as error:
+            return {'error_type': 'validation',
+                    'error_message': str(error)}, 404
+        except mongo_errors as error:  # noqa: E0712
+            return {'error_type': 'validation',
+                    'error_message': str(error)}, 400
+    return wrapper

--- a/abe/resource_models/event_resources.py
+++ b/abe/resource_models/event_resources.py
@@ -119,7 +119,7 @@ class EventApi(Resource):
         if new_event.labels == []:  # if no labels were given
             new_event.labels = ['unlabeled']
         if 'recurrence' in new_event:  # if this is a recurring event
-            if not new_event.recurrence.forever:  # if it doesn't recurr forever
+            if not new_event.recurrence.forever:  # if it doesn't recur forever
                 # find the end of the recurrence
                 new_event.recurrence_end = find_recurrence_end(new_event)
         new_event.save()

--- a/abe/resource_models/ics_resources.py
+++ b/abe/resource_models/ics_resources.py
@@ -6,12 +6,12 @@ import logging
 import requests
 from flask import Response,  request
 from icalendar import Calendar
-from mongoengine import ValidationError
 
 from abe import database as db
 from abe.auth import edit_auth_required
 from abe.helper_functions.converting_helpers import request_to_dict
 from abe.helper_functions.ics_helpers import extract_ics, mongo_to_ics
+from abe.helper_functions.mongodb_helpers import mongo_resource_errors
 from abe.helper_functions.query_helpers import event_query, get_to_event_search
 from flask_restplus import Namespace, Resource, fields
 
@@ -28,6 +28,7 @@ class ICSApi(Resource):
     """API for interacting with ics feeds"""
 
     @api.deprecated
+    @mongo_resource_errors
     def get(self):
         """
         Deprecated, use SubscriptionICSFeed get instead.
@@ -45,26 +46,22 @@ class ICSApi(Resource):
                         headers={"Content-Disposition": cd})
 
     @edit_auth_required
+    @mongo_resource_errors
     @api.expect(ics_model)
     def post(self):
         """
         Converts an ICS feed input to mongoDB objects
         """
-        try:
-            # reads outside ics feed
-            url = request_to_dict(request)
-            data = requests.get(url['url'].strip()).content.decode('utf-8')
-            cal = Calendar.from_ical(data)
-            if 'labels' in url:
-                labels = url['labels']
-            else:
-                labels = ['unlabeled']
+        # reads outside ics feed
+        url = request_to_dict(request)
+        data = requests.get(url['url'].strip()).content.decode('utf-8')
+        cal = Calendar.from_ical(data)
+        if 'labels' in url:
+            labels = url['labels']
+        else:
+            labels = ['unlabeled']
 
-            extract_ics(cal, url['url'], labels)
-        except ValidationError as error:
-            return {'error_type': 'validation',
-                    'validation_errors': [str(err) for err in error.errors],
-                    'error_message': error.message}, 400
+        extract_ics(cal, url['url'], labels)
 
 
 api.add_resource(ICSApi, '/', methods=['GET', 'POST'], endpoint='ics')

--- a/abe/resource_models/label_resources.py
+++ b/abe/resource_models/label_resources.py
@@ -56,6 +56,7 @@ class LabelApi(Resource):
         """Create new label with parameters passed in through args or form"""
         received_data = request_to_dict(request)
         logging.debug("Received POST data: %s", received_data)
+        # TODO: replace this try:except: by just the try: block, after PR #229 is merged
         try:
             new_label = db.Label(**received_data)
             new_label.save()
@@ -64,8 +65,7 @@ class LabelApi(Resource):
                     'validation_errors': str(error),  # [str(err) for err in error.errors or [error]],
                     'error_message': error.message,
                     }, 400
-        else:  # return success
-            return mongo_to_dict(new_label), 201
+        return mongo_to_dict(new_label), 201
 
     @edit_auth_required
     @mongo_resource_errors
@@ -79,14 +79,14 @@ class LabelApi(Resource):
         if not result:
             return "Label not found with identifier '{}'".format(label_name), 404
 
+        # TODO: replace this try:except: by just the try: block, after PR #229 is merged
         try:
             result.update(**received_data)
         except ValidationError as error:
             return {'error_type': 'validation',
                     'validation_errors': [str(err) for err in error.errors or [error]],
                     'error_message': error.message}, 400
-        else:  # return success
-            return mongo_to_dict(result)
+        return mongo_to_dict(result)
 
     @edit_auth_required
     @mongo_resource_errors

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -15,6 +15,18 @@ class LabelsTestCase(abe_unittest.TestCase):
         self.app = abe.app.app.test_client()
         sample_data.load_data(self.db)
 
+    def get_label_by_id(self, id):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['id'] == id)
+
+    def get_label_by_name(self, name):
+        response = self.app.get('/labels/')
+        self.assertEqual(response.status_code, 200)
+        return next(label for label in flask.json.loads(response.data)
+                    if label['name'] == name)
+
     def test_get(self):
         response = self.app.get('/labels/')
         self.assertEqual(response.status_code, 200)
@@ -39,14 +51,13 @@ class LabelsTestCase(abe_unittest.TestCase):
             )
             self.assertEqual(response.status_code, 201)
 
-        # FIXME:
-        # with self.subTest("fails on a duplicate label name"):
-        #     response = self.app.post(
-        #         '/labels/',
-        #         data=flask.json.dumps(label1),
-        #         content_type='application/json'
-        #     )
-        #     self.assertEqual(response.status_code, 400)
+        with self.subTest("fails on a duplicate label name"):
+            response = self.app.post(
+                '/labels/',
+                data=flask.json.dumps(label1),
+                content_type='application/json'
+            )
+            self.assertEqual(response.status_code, 400)
 
         with self.subTest("fails when fields are missing"):
             response = self.app.post(
@@ -94,17 +105,39 @@ class LabelsTestCase(abe_unittest.TestCase):
             self.assertEqual(response.status_code, 201)
 
     def test_put(self):
-        # TODO: test success
         # TODO: test invalid id
         # TODO: test invalid data
+        label_id = self.get_label_by_name('library')['id']
+        label_data = {
+            'description': 'New description',
+        }
+
         with self.subTest("fails when the client is not authorized"):
             response = self.app.put(
-                '/labels/library',
+                '/labels/' + label_id,
                 data=flask.json.dumps({'description': 'new description'}),
                 content_type='application/json',
                 headers={'X-Forwarded-For': '192.168.1.1'}
             )
             self.assertEqual(response.status_code, 401)
+
+        with self.subTest("succeeds with an authorized client"):
+            response = self.app.put(
+                '/labels/' + label_id,
+                data=flask.json.dumps(label_data),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 200)
+            label = self.get_label_by_id(label_id)
+            self.assertEqual(label['description'], 'New description')
+
+        with self.subTest("fails with invalid data"):
+            response = self.app.put(
+                '/labels/' + label_id,
+                data=flask.json.dumps({'colorx': 'invalid-color'}),
+                content_type='application/json',
+            )
+            self.assertEqual(response.status_code, 400)
 
     def test_delete(self):
         # TODO: test success


### PR DESCRIPTION
Single-field validation errors caused server 500's, because error.errors is None in that case.

Fixed that, factored MongoDB error handling into a decorator, and handle some other MongoDB errors.

This change adds the decorators but doesn't remove the previous `try` from `label_resources.py`, to avoid a merge conflict with a pending PR.

It adds error tests of varying comprehensiveness for labels and events. It doesn't test the changed code for ics and subscription resources, but the decorators are tested by the other test cases, and the error conditions for these other resources weren't tested before (so this isn't a coverage regression).