### PR TITLE
Restore codecov code coverage 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ env:
   - PIPENV_IGNORE_VIRTUALENVS=1
 
 install:
-  - cp .env.template .env
   - pip install pipenv
   - pipenv install --dev --ignore-pipfile
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
   - pipenv run flake8 abe tests *.py
 
 after_success:
-  - codecov
+  - pipenv run codecov
 
 notifications:
   slack:


### PR DESCRIPTION
## Description

271da6d *Run travis `codecov` inside `pipenv run`*

Fixes #172.

4f5a7b2 *Remove cp .env.template .env from travis.yml*

The defaults should work. This now tests that they do.

## Required
Changes must conform to these requirements:
* [x] `python -m unittest` passes.  All new and existing tests pass.
* [x] `flake8 abe tests *.py` passes. All new code follows the code style of this project.

## Specific
These only apply if your changes touch certain areas of the project:
* [ ] API changes are documented with swagger. (Not all the API is covered yet)
* [ ] New env variables are added to `.env.template`

## Aspirational
We don't yet require these, but they are nice to have:
* [ ] New code is covered by new or existing tests.
* [ ] Changed code is covered by new or existing tests.
